### PR TITLE
[release 4.7] fix race condition in service defined by templates/common/on-prem/units/baremetal-system-connections-mount.yaml

### DIFF
--- a/templates/common/on-prem/units/baremetal-system-connections-mount.yaml
+++ b/templates/common/on-prem/units/baremetal-system-connections-mount.yaml
@@ -3,6 +3,7 @@ enabled: true
 contents: |
   [Unit]
   After=systemd-tmpfiles-setup.service
+  DefaultDependencies=no
   [Mount]
   Where=/etc/NetworkManager/system-connections-merged
   What=overlay


### PR DESCRIPTION
Fix race condition in service defined by templates/common/on-prem/units/baremetal-system-connections-mount.yaml

set ` DefaultDependencies=no`

This prevents a systemd loop dependency like:

```
 journalctl -b | grep -i local-fs.target
Mar 21 14:04:31 localhost systemd[1]: local-fs.target: Found ordering cycle on etc-NetworkManager-system\x2dconnections\x2dmerged.mount/start
Mar 21 14:04:31 localhost systemd[1]: local-fs.target: Found dependency on systemd-tmpfiles-setup.service/start
Mar 21 14:04:31 localhost systemd[1]: local-fs.target: Found dependency on local-fs.target/start
Mar 21 14:04:31 localhost systemd[1]: local-fs.target: Job etc-NetworkManager-system\x2dconnections\x2dmerged.mount/start deleted to break ordering cycle starting with local-fs.target/start
```
This issue can cause networking and login to fail.

**- Description for the changelog**
Fix race condition in service defined by templates/common/on-prem/units/baremetal-system-connections-mount.yaml
