### PR TITLE
daemon: Make SSH keys owned by core user

### DIFF
--- a/pkg/daemon/update.go
+++ b/pkg/daemon/update.go
@@ -1725,8 +1725,8 @@ func (dn *Daemon) atomicallyWriteSSHKey(keys string) error {
 	// Keys should only be written to "/home/core/.ssh"
 	// Once Users are supported fully this should be writing to PasswdUser.HomeDir
 	glog.Infof("Writing SSHKeys at %q", authKeyPath)
-
-	if err := writeFileAtomicallyWithDefaults(authKeyPath, []byte(keys)); err != nil {
+	// write the file and ensure it's owned by the core user (uid: 1000, gid: 1000)
+	if err := writeFileAtomically(authKeyPath, []byte(keys), defaultDirectoryPermissions, defaultFilePermissions, 1000, 1000); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/openshift/okd/issues/655

**- What I did**
In OKD, the file does not exist and is therefore newly written
via the atomicallyWriteSSHKey function.
This change ensures the ownership is explicitly set to the core user
and group (uid 1000/gid 1000) as it'll otherwise default to root.

**- How to verify it**
CRC?

**- Description for the changelog**
daemon: Make SSH keys owned by core user
